### PR TITLE
Set `SkipDryRunOnMissingResource=true` for `KeepalivedGroup` resources

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -55,6 +55,9 @@ local keepalived_groups = std.filter(
       kube._Object('redhatcop.redhat.io/v1alpha1', 'KeepalivedGroup', formated_name) {
         metadata+: {
           namespace: params.namespace,
+          annotations+: {
+            'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+          },
         },
         spec+: {
           image: image,

--- a/tests/golden/defaults/openshift4-keepalived/openshift4-keepalived/20_keepalived_groups.yaml
+++ b/tests/golden/defaults/openshift4-keepalived/openshift4-keepalived/20_keepalived_groups.yaml
@@ -1,7 +1,8 @@
 apiVersion: redhatcop.redhat.io/v1alpha1
 kind: KeepalivedGroup
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     name: group-1
   name: group-1
@@ -18,7 +19,8 @@ spec:
 apiVersion: redhatcop.redhat.io/v1alpha1
 kind: KeepalivedGroup
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     name: group-2
   name: group-2


### PR DESCRIPTION
This fixes the initial deployment of the component. Without the annotation ArgoCD can't validate the `KeepalivedGroup` resources before applying the manifests, which in turn means that the CRD won't ever be available.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
