### PR TITLE
Use latest image for RedHat Keepalived

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -24,7 +24,8 @@
       "github_owner": "appuio",
       "github_name": "component-openshift4-keepalived",
       "github_url": "https://github.com/appuio/component-openshift4-keepalived",
-      "_template": "https://github.com/projectsyn/commodore-component-template.git"
+      "_template": "https://github.com/projectsyn/commodore-component-template.git",
+      "_commit": "98d16f99766e6c6d97322dbe42e058f0e2bf73d0"
     }
   },
   "directory": null

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,7 +2,15 @@ parameters:
   openshift4_keepalived:
     =_metadata:
       multi_tenant: true
+
     namespace: openshift-keepalived-operator
+
     channel: alpha
-    openshift_version: '4.9'
+
+    images:
+      keepalived:
+        registry: registry.redhat.io
+        repository: openshift4/ose-keepalived-ipfailover-rhel9
+        tag: v4.18
+
     keepalived_groups: {}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -6,7 +6,7 @@ local operatorlib = import 'lib/openshift4-operators.libsonnet';
 local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift4_keepalived;
-local image = 'registry.redhat.io/openshift4/ose-keepalived-ipfailover:v' + params.openshift_version;
+local image = '%(registry)s/%(repository)s:%(tag)s' % params.images.keepalived;
 
 local namespace =
   kube.Namespace(params.namespace)

--- a/docs/modules/ROOT/pages/how-tos/upgrade-v1-v2.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-v1-v2.adoc
@@ -1,0 +1,26 @@
+= Upgrade `component-openshift4-keepalived` from `v1.x` to `v2.x`
+
+Version 2.x changes how the image used for keepalived is specified.
+
+
+== Migration steps
+
+If you use the component with the default configuration, you don't need to do anything.
+
+If you are using an the `openshift_version` parameter, you need to change the following:
+
+[source,yaml]
+----
+openshift4_keepalived:
+  images:
+    keepalived:
+      tag: v4.18 <1>
+----
+<1> The tag is the version of the keepalived image to use, replacing the parameter `openshift_version`.
+
+
+== Explanation of configuration changes
+
+=== legacy `openshift_version`
+
+The parameter `openshift_version` has been replaced by the `images.keepalived.tag` parameter.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,6 +10,7 @@ default:: `openshift-operator-community`
 
 The namespace in which to deploy this component.
 
+
 == `channel`
 
 [horizontal]
@@ -18,13 +19,15 @@ default:: `alpha`
 
 The channel from where the operator should be fetched.
 
-== `openshift_version`
+
+== `images`
 
 [horizontal]
-type:: string
-default:: `4.9`
+type:: dictionary
+default:: See https://github.com/projectsyn/espejote/blob/master/class/defaults.yml[`class/defaults.yml`]
 
-The OpenShift version used to set the corresesponding image tag for the KeepalivedGroup(s).
+The images to use for this component.
+
 
 == `keepalived_groups`
 
@@ -49,7 +52,6 @@ parameters:
     keepalived_groups:
       group_1:
         spec:
-          image: registry.redhat.io/openshift4/ose-keepalived-ipfailover
           interface: ens3
           nodeSelector:
             node-role.kubernetes.io/loadbalancer: ""
@@ -58,7 +60,7 @@ parameters:
             - 2
       group_2:
         spec:
-          image: registry.redhat.io/openshift4/ose-keepalived-ipfailover
+          image: registry.redhat.io/openshift4/ose-keepalived-ipfailover-rhel9:latest
           interface: ens4
           nodeSelector:
             node-role.kubernetes.io/nodeport: ""

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,6 +1,13 @@
 applications:
   - openshift4-operators as openshift-operators-redhat
+
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-operators/master/lib/openshift4-operators.libsonnet
+        output_path: vendor/lib/openshift4-operators.libsonnet
+
   facts:
     distribution: openshift4
 
@@ -9,6 +16,7 @@ parameters:
     defaultInstallPlanApproval: Automatic
     defaultSourceNamespace: openshift-marketplace
     defaultSource: redhat-operators
+
   openshift4_keepalived:
     keepalived_groups:
       group_1:
@@ -21,7 +29,7 @@ parameters:
             - 2
       group_2:
         spec:
-          image: registry.redhat.io/openshift4/ose-keepalived-ipfailover:latest
+          image: registry.redhat.io/openshift4/ose-keepalived-ipfailover-rhel9:latest
           interface: ens4
           nodeSelector:
             node-role.kubernetes.io/nodeport: ""
@@ -29,8 +37,3 @@ parameters:
             - 3
             - 4
       group_3: null
-  kapitan:
-    dependencies:
-      - type: https
-        source: https://raw.githubusercontent.com/appuio/component-openshift4-operators/master/lib/openshift4-operators.libsonnet
-        output_path: vendor/lib/openshift4-operators.libsonnet

--- a/tests/golden/defaults/openshift4-keepalived/openshift4-keepalived/20_keepalived_groups.yaml
+++ b/tests/golden/defaults/openshift4-keepalived/openshift4-keepalived/20_keepalived_groups.yaml
@@ -11,7 +11,7 @@ spec:
   blacklistRouterIDs:
     - 1
     - 2
-  image: registry.redhat.io/openshift4/ose-keepalived-ipfailover:v4.9
+  image: registry.redhat.io/openshift4/ose-keepalived-ipfailover-rhel9:v4.18
   interface: ens3
   nodeSelector:
     node-role.kubernetes.io/loadbalancer: ''
@@ -29,7 +29,7 @@ spec:
   blacklistRouterIDs:
     - 3
     - 4
-  image: registry.redhat.io/openshift4/ose-keepalived-ipfailover:latest
+  image: registry.redhat.io/openshift4/ose-keepalived-ipfailover-rhel9:latest
   interface: ens4
   nodeSelector:
     node-role.kubernetes.io/nodeport: ''


### PR DESCRIPTION
RedHats Keepalived image changed from `ose-keepalived-ipfailover` to `ose-keepalived-ipfailover-rhel9`. This change will also use best-practice for defining images, thus will be a breaking change.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
